### PR TITLE
Fix parsing of the level argument

### DIFF
--- a/alfresco-value-assistance-repo/alfresco-value-assistance-repo/src/main/amp/config/alfresco/extension/templates/webscripts/org/orderofthebee/picklist.get.js
+++ b/alfresco-value-assistance-repo/alfresco-value-assistance-repo/src/main/amp/config/alfresco/extension/templates/webscripts/org/orderofthebee/picklist.get.js
@@ -38,10 +38,9 @@ function main() {
 		pickListName = args.name;
 	}
 
-	if (args.level === null) {
+	pickListLevel = parseInt(args.level, 10);
+	if (isNaN(pickListLevel)) {
 		pickListLevel = 1;
-	} else {
-		pickListLevel = parseInt(args.level);
 	}
 
 	includeBlankItem = args.includeBlankItem;


### PR DESCRIPTION
Some values for the `level` argument can cause `pickListLevel` to be equal to `NaN`. This is particularly the case when using `dynamic-selectmany.ftl`, the `level` argument is an empty string and `parseInt()` returns the special value `NaN`.
The fix simply sets `pickListLevel` to 1 when `parseInt()` returns `NaN`.